### PR TITLE
Remove conflicted symlink

### DIFF
--- a/manifests/plugins/cisco.pp
+++ b/manifests/plugins/cisco.pp
@@ -171,11 +171,11 @@ class neutron::plugins::cisco(
 
   # In RH, this link is used to start Neutron process but in Debian, it's used only
   # to manage database synchronization.
-  file {'/etc/neutron/plugin.ini':
-    ensure  => link,
-    target  => '/etc/neutron/plugins/cisco/cisco_plugins.ini',
-    require => Package['neutron-plugin-cisco']
-  }
+  #file {'/etc/neutron/plugin.ini':
+  #  ensure  => link,
+  #  target  => '/etc/neutron/plugins/cisco/cisco_plugins.ini',
+  #  require => Package['neutron-plugin-cisco']
+  #}
 
 
 }


### PR DESCRIPTION
A recent change to the upstream manifests added a symlink
that isn't actually useful with modern versions of the Cisco
plugin, and causes a duplicate define error if used in
conjuction with the OVS plugin.  This patch removes it.
We'll carry this patch temporarily due to time constraints,
but it will be dealt with upstream in a work-in-progress
refactoring of the Cisco plugin manifest.

Partial-Bug: #1276168
