### PR TITLE
Fix missing plugin --config-file arguments

### DIFF
--- a/manifests/agents/ovs.pp
+++ b/manifests/agents/ovs.pp
@@ -47,7 +47,7 @@ class neutron::agents::ovs (
 
     file_line { 'add modified exec to init2':
       path    => '/etc/init/neutron-plugin-openvswitch-agent.conf',
-      line    => 'exec start-stop-daemon --start --chuid neutron --exec /usr/bin/neutron-openvswitch-agent -- --config-file=/etc/neutron/neutron.conf --log-file=/var/log/neutron/openvswitch-agent.log',
+      line    => 'exec start-stop-daemon --start --chuid neutron --exec /usr/bin/neutron-openvswitch-agent -- --config-file=/etc/neutron/neutron.conf --config-file /etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini --log-file=/var/log/neutron/openvswitch-agent.log',
       require => File_line['comment init file2'],
     }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -189,26 +189,20 @@ class neutron::server (
       notify  => Service['neutron-server'],
     }
 
+    file_line { 'modify NEUTRON_PLUGIN_CONFIG setting':
+      path    => '/etc/default/neutron-server',
+      line    => 'NEUTRON_PLUGIN_CONFIG="/etc/neutron/plugin.ini"',
+      require => File_line['change default file'],
+      notify  => Service['neutron-server'],
+    }
+
     file_line { 'comment init file':
       path  => '/etc/init/neutron-plugin-openvswitch-agent.conf',
       line  => '#exec start-stop-daemon --start --chuid neutron --exec /usr/bin/neutron-openvswitch-agent -- --config-file=/etc/neutron/neutron.conf --config-file=/etc/neutron/plugins/ml2/ml2_conf.ini --log-file=/var/log/neutron/openvswitch-agent.log',
       match => 'exec start-stop-daemon --start --chuid neutron --exec /usr/bin/neutron-openvswitch-agent -- --config-file=/etc/neutron/neutron.conf --config-file=/etc/neutron/plugins/ml2/ml2_conf.ini --log-file=/var/log/neutron/openvswitch-agent.log',
       require => [ Package['neutron-plugin-openvswitch-agent'], File_line['change default file'] ],
     }
-
-    file_line { 'add modified exec to init':
-      path    => '/etc/init/neutron-plugin-openvswitch-agent.conf',
-      line    => 'exec start-stop-daemon --start --chuid neutron --exec /usr/bin/neutron-openvswitch-agent -- --config-file=/etc/neutron/neutron.conf --log-file=/var/log/neutron/openvswitch-agent.log',
-      require => File_line['comment init file'],
-    }
-
-    exec { 'bound neutron-plugin-openvswitch-agent':
-      command => '/sbin/stop neutron-plugin-openvswitch-agent && sleep 1 && /sbin/start neutron-plugin-openvswitch-agent',
-      require => File_line['add modified exec to init'],
-      unless  => '/bin/ps -ef | /bin/grep neutron-openvswitch-agent | /bin/grep -v grep | /bin/grep -v ml2',
-    }
   }
-
 
   Neutron_config<||>     ~> Service['neutron-server']
   Neutron_api_config<||> ~> Service['neutron-server']


### PR DESCRIPTION
Ubuntu has broken init scripts for the ovs agent and
neutron-server in 14.04 in that they assume you're using the
ml2 plugin.  The server init script reads an /etc/default file
which can be modified to point to other plugin configs.  The
OVS agent has no such file (the config file is coded into the
init script).  A previous patch partly worked around the issue
by modifying the relevant files to prevent the ml2 config files
from being passed as --config-file arguments to the relevant
services.  However, that patch doesn't replace the ml2 config
files with the ovs config files, so the services start without
the config information contained in
/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini.  This
patch corrects the problem by doing two things: first, it adds
the ovs_neutron_plugin.ini file to the ovs agent startup files.
Second, it points neutron-server to /etc/neutron/plugin.ini, which
is a symlink that points to whatever plugin file is actually being
used (thus solving the neutron-server problem not only for the
OVS plugin, but potentially other plugins as well).

Closes-Bug: #1322012
